### PR TITLE
Fix libpng and bitdepth. Add tilemaps.

### DIFF
--- a/include/gfx/gb.h
+++ b/include/gfx/gb.h
@@ -19,7 +19,9 @@
 
 void png_to_gb(struct PNGImage png, struct GBImage *gb);
 void output_file(struct Options opts, struct GBImage gb);
-void output_tilemap_file(struct Options opts);
+int get_tile_index(uint8_t *tile, uint8_t **tiles, int num_tiles, int tile_size);
+void create_tilemap(struct Options opts, struct GBImage *gb, struct Tilemap *tilemap);
+void output_tilemap_file(struct Options opts, struct Tilemap tilemap);
 void output_palette_file(struct Options opts, struct PNGImage png);
 
 #endif

--- a/include/gfx/main.h
+++ b/include/gfx/main.h
@@ -35,6 +35,7 @@ struct Options {
 	bool hardfix;
 	bool fix;
 	bool horizontal;
+	bool unique;
 	int trim;
 	char *mapfile;
 	bool mapout;
@@ -65,6 +66,11 @@ struct GBImage {
 	int size;
 	bool horizontal;
 	int trim;
+};
+
+struct Tilemap {
+	uint8_t *data;
+	int size;
 };
 
 int depth, colors;

--- a/src/gfx/gb.c
+++ b/src/gfx/gb.c
@@ -39,7 +39,14 @@ void png_to_gb(struct PNGImage png, struct GBImage *gb) {
 
 	for(y = 0; y < png.height; y++) {
 		for(x = 0; x < png.width; x++) {
-			index = png.data[y][x * depth / 8] >> (8 - depth - ((x % (8 / depth)) * depth)) & 3;
+			if (png.depth == 1) {
+				index = png.data[y][x];
+			} else {
+				index = png.data[y][(x * png.depth) / 8];
+				index >>= (8 - png.depth - ((x % (8 / png.depth)) * depth));
+			}
+			index &= (1 << depth) - 1;
+
 			if(png.type == PNG_COLOR_TYPE_GRAY) {
 				index = colors - 1 - index;
 			}

--- a/src/gfx/gb.c
+++ b/src/gfx/gb.c
@@ -39,17 +39,9 @@ void png_to_gb(struct PNGImage png, struct GBImage *gb) {
 
 	for(y = 0; y < png.height; y++) {
 		for(x = 0; x < png.width; x++) {
-			if (png.depth == 1) {
-				index = png.data[y][x];
-			} else {
-				index = png.data[y][(x * png.depth) / 8];
-				index >>= (8 - png.depth - ((x % (8 / png.depth)) * depth));
-			}
-			index &= (1 << depth) - 1;
+			index = png.data[y][x];
+			index &= colors - 1;
 
-			if(png.type == PNG_COLOR_TYPE_GRAY) {
-				index = colors - 1 - index;
-			}
 			if(!gb->horizontal) {
 				byte = y * depth + x / 8 * png.height / 8 * 8 * depth;
 			} else {

--- a/src/gfx/gb.c
+++ b/src/gfx/gb.c
@@ -71,13 +71,91 @@ void output_file(struct Options opts, struct GBImage gb) {
 	fclose(f);
 }
 
-void output_tilemap_file(struct Options opts) {
+int get_tile_index(uint8_t *tile, uint8_t **tiles, int num_tiles, int tile_size) {
+	int i, j;
+	for (i = 0; i < num_tiles; i++) {
+		for (j = 0; j < tile_size; j++) {
+			if (tile[j] != tiles[i][j]) {
+				break;
+			}
+		}
+		if (j >= tile_size) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+void create_tilemap(struct Options opts, struct GBImage *gb, struct Tilemap *tilemap) {
+	int i, j;
+	int gb_i;
+	int tile_size;
+	int max_tiles;
+	int num_tiles;
+	int index;
+	int gb_size;
+	uint8_t *tile;
+	uint8_t **tiles;
+
+	tile_size = sizeof(uint8_t) * depth * 8;
+	gb_size = gb->size - (gb->trim * tile_size);
+	max_tiles = gb_size / tile_size;
+	tiles = malloc(sizeof(uint8_t*) * max_tiles);
+	num_tiles = 0;
+
+	tilemap->data = malloc(sizeof(uint8_t) * max_tiles);
+	tilemap->size = 0;
+
+	gb_i = 0;
+	while (gb_i < gb_size) {
+		tile = malloc(tile_size);
+		for (i = 0; i < tile_size; i++) {
+			tile[i] = gb->data[gb_i];
+			gb_i++;
+		}
+		if (opts.unique) {
+			index = get_tile_index(tile, tiles, num_tiles, tile_size);
+			if (index < 0) {
+				index = num_tiles;
+				tiles[num_tiles] = tile;
+				num_tiles++;
+			}
+		} else {
+			index = num_tiles;
+			tiles[num_tiles] = tile;
+			num_tiles++;
+		}
+		tilemap->data[tilemap->size] = index;
+		tilemap->size++;
+	}
+
+	if (opts.unique) {
+		free(gb->data);
+		gb->data = malloc(tile_size * num_tiles);
+		for (i = 0; i < num_tiles; i++) {
+			tile = tiles[i];
+			for (j = 0; j < tile_size; j++) {
+				gb->data[i * tile_size + j] = tile[j];
+			}
+		}
+		gb->size = i * tile_size;
+	}
+
+	for (i = 0; i < num_tiles; i++) {
+		free(tiles[i]);
+	}
+	free(tiles);
+}
+
+void output_tilemap_file(struct Options opts, struct Tilemap tilemap) {
 	FILE *f;
 
 	f = fopen(opts.mapfile, "wb");
 	if(!f) {
 		err(EXIT_FAILURE, "Opening tilemap file '%s' failed", opts.mapfile);
 	}
+
+	fwrite(tilemap.data, 1, tilemap.size, f);
 	fclose(f);
 
 	if(opts.mapout) {

--- a/src/gfx/gb.c
+++ b/src/gfx/gb.c
@@ -40,7 +40,7 @@ void png_to_gb(struct PNGImage png, struct GBImage *gb) {
 	for(y = 0; y < png.height; y++) {
 		for(x = 0; x < png.width; x++) {
 			index = png.data[y][x];
-			index &= colors - 1;
+			index &= (1 << depth) - 1;
 
 			if(!gb->horizontal) {
 				byte = y * depth + x / 8 * png.height / 8 * 8 * depth;

--- a/src/gfx/main.c
+++ b/src/gfx/main.c
@@ -18,8 +18,8 @@
 
 static void usage(void) {
 	printf(
-"Usage: rgbgfx [-v] [-F] [-f] [-h] [-d #] [-x #] [-t mapfile] [-T] [-p palfile]\n"
-"              [-P] [-o outfile] infile\n");
+"Usage: rgbgfx [-D] [-v] [-F] [-f] [-d #] [-h] [-x #] [-t mapfile] [-T]\n"
+"              [-p palfile] [-P] [-o outfile] infile\n");
 	exit(1);
 }
 

--- a/src/gfx/main.c
+++ b/src/gfx/main.c
@@ -94,7 +94,7 @@ int main(int argc, char *argv[]) {
 	if(depth != 1 && depth != 2) {
 		errx(EXIT_FAILURE, "Depth option must be other 1 or 2.");
 	}
-	colors = (depth == 1 ? 2 : depth * depth);
+	colors = 1 << depth;
 
 	input_png_file(opts, &png);
 

--- a/src/gfx/main.c
+++ b/src/gfx/main.c
@@ -19,7 +19,7 @@
 static void usage(void) {
 	printf(
 "Usage: rgbgfx [-D] [-v] [-F] [-f] [-d #] [-h] [-x #] [-t mapfile] [-T]\n"
-"              [-p palfile] [-P] [-o outfile] infile\n");
+"              [-u] [-p palfile] [-P] [-o outfile] infile\n");
 	exit(1);
 }
 
@@ -28,6 +28,7 @@ int main(int argc, char *argv[]) {
 	struct Options opts = {0};
 	struct PNGImage png = {0};
 	struct GBImage gb = {0};
+	struct Tilemap tilemap = {0};
 	char *ext;
 	const char *errmsg = "Warning: The PNG's %s setting is not the same as the setting defined on the command line.";
 
@@ -41,7 +42,7 @@ int main(int argc, char *argv[]) {
 
 	depth = 2;
 
-	while((ch = getopt(argc, argv, "DvFfd:hx:Tt:Pp:o:")) != -1) {
+	while((ch = getopt(argc, argv, "DvFfd:hx:Tt:uPp:o:")) != -1) {
 		switch(ch) {
 		case 'D':
 			opts.debug = true;
@@ -68,6 +69,9 @@ int main(int argc, char *argv[]) {
 			break;
 		case 't':
 			opts.mapfile = optarg;
+			break;
+		case 'u':
+			opts.unique = true;
 			break;
 		case 'P':
 			opts.palout = true;
@@ -211,13 +215,17 @@ int main(int argc, char *argv[]) {
 	gb.trim = opts.trim;
 	gb.horizontal = opts.horizontal;
 
-	if(*opts.outfile) {
+	if(*opts.outfile || *opts.mapfile) {
 		png_to_gb(png, &gb);
+		create_tilemap(opts, &gb, &tilemap);
+	}
+
+	if(*opts.outfile) {
 		output_file(opts, gb);
 	}
 
 	if(*opts.mapfile) {
-		output_tilemap_file(opts);
+		output_tilemap_file(opts, tilemap);
 	}
 
 	if(*opts.palfile) {

--- a/src/gfx/main.c
+++ b/src/gfx/main.c
@@ -92,7 +92,7 @@ int main(int argc, char *argv[]) {
 	opts.infile = argv[argc - 1];
 
 	if(depth != 1 && depth != 2) {
-		errx(EXIT_FAILURE, "Depth option must be other 1 or 2.");
+		errx(EXIT_FAILURE, "Depth option must be either 1 or 2.");
 	}
 	colors = 1 << depth;
 
@@ -156,7 +156,7 @@ int main(int argc, char *argv[]) {
 
 	if(!strequ(png.palfile, opts.palfile)) {
 		if(opts.verbose) {
-			warnx(errmsg, "pallette file");
+			warnx(errmsg, "palette file");
 		}
 		if(opts.hardfix) {
 			png.palfile = opts.palfile;
@@ -168,7 +168,7 @@ int main(int argc, char *argv[]) {
 
 	if(png.palout != opts.palout) {
 		if(opts.verbose) {
-			warnx(errmsg, "pallette file");
+			warnx(errmsg, "palette file");
 		}
 		if(opts.hardfix) {
 			png.palout = opts.palout;

--- a/src/gfx/png.c
+++ b/src/gfx/png.c
@@ -65,7 +65,7 @@ void input_png_file(struct Options opts, struct PNGImage *img) {
 
 		if(img->type == PNG_COLOR_TYPE_GRAY) {
 			if(img->depth < 8) {
-				png_set_gray_1_2_4_to_8(img->png);
+				png_set_expand_gray_1_2_4_to_8(img->png);
 			}
 			png_set_gray_to_rgb(img->png);
 		} else {
@@ -143,7 +143,7 @@ void input_png_file(struct Options opts, struct PNGImage *img) {
 		}
 
 		/* Also unfortunately, this sets it at 8 bit, and I cant find any option to reduce to 2 or 1 bit. */
-		png_set_dither(img->png, palette, colors, colors, NULL, 1);
+		png_set_quantize(img->png, palette, colors, colors, NULL, 1);
 
 		if(!has_palette) {
 			png_set_PLTE(img->png, img->info, palette, colors);
@@ -202,7 +202,7 @@ void get_text(struct PNGImage *png) {
 		text[i].text = text[i + numremoved].text;
 		text[i].compression = text[i + numremoved].compression;
 	}
-	png->info->num_text -= numremoved;
+	png_set_text(png->png, png->info, text, numtxts - numremoved);
 }
 
 void set_text(struct PNGImage *png) {

--- a/src/gfx/png.c
+++ b/src/gfx/png.c
@@ -62,7 +62,9 @@ void input_png_file(struct Options opts, struct PNGImage *img) {
 		if(opts.verbose) {
 			warnx("Image bit depth is not %i (is %i).", depth, img->depth);
 		}
+	}
 
+	if (img->depth != 2) {
 		if(img->type == PNG_COLOR_TYPE_GRAY) {
 			if(img->depth < 8) {
 				png_set_expand_gray_1_2_4_to_8(img->png);

--- a/src/gfx/png.c
+++ b/src/gfx/png.c
@@ -71,6 +71,9 @@ void input_png_file(struct Options opts, struct PNGImage *img) {
 			}
 			png_set_gray_to_rgb(img->png);
 		} else {
+			if(img->depth < 8) {
+				png_set_expand_gray_1_2_4_to_8(img->png);
+			}
 			has_palette = png_get_PLTE(img->png, img->info, &palette, &colors);
 		}
 

--- a/src/gfx/png.c
+++ b/src/gfx/png.c
@@ -64,7 +64,7 @@ void input_png_file(struct Options opts, struct PNGImage *img) {
 		}
 	}
 
-	if (img->depth != 2) {
+	if (true) {
 		if(img->type == PNG_COLOR_TYPE_GRAY) {
 			if(img->depth < 8) {
 				png_set_expand_gray_1_2_4_to_8(img->png);

--- a/src/gfx/png.c
+++ b/src/gfx/png.c
@@ -60,7 +60,7 @@ void input_png_file(struct Options opts, struct PNGImage *img) {
 
 	if(img->depth != depth) {
 		if(opts.verbose) {
-			warnx("Image bit depth is not %i.", depth);
+			warnx("Image bit depth is not %i (is %i).", depth, img->depth);
 		}
 
 		if(img->type == PNG_COLOR_TYPE_GRAY) {

--- a/src/gfx/rgbgfx.1
+++ b/src/gfx/rgbgfx.1
@@ -54,6 +54,8 @@ Same as
 but the tilemap file output name is made by taking the input filename,
 removing the file extension, and appending
 .Pa .tilemap .
+.It Fl u
+Truncate repeated tiles. Useful with tilemaps.
 .It Fl v
 Verbose.
 Print errors when the command line parameters and the parameters in
@@ -66,6 +68,11 @@ The following will take a PNG file with a bitdepth of 1, 2, or 8, and output
 planar 2bpp data:
 .Pp
 .D1 $ rgbgfx -o out.2bpp in.png
+.Pp
+The following creates a planar 2bpp file with only unique tiles, and its tilemap
+.Pa out.tilemap :
+.Pp
+.D1 $ rgbgfx -T -u -o out.2bpp in.png
 .Pp
 The following will do nothing:
 .Pp

--- a/src/gfx/rgbgfx.1
+++ b/src/gfx/rgbgfx.1
@@ -6,8 +6,9 @@
 .Nd Game Boy graphics converter
 .Sh SYNOPSIS
 .Nm rgbgfx
-.Op Fl bfFhPTv
+.Op Fl DfFhPTv
 .Op Fl o Ar outfile
+.Op Fl d Ar depth
 .Op Fl p Ar palfile
 .Op Fl t Ar mapfile
 .Op Fl x Ar tiles
@@ -18,9 +19,8 @@ The
 program converts PNG images into the Nintendo Game Boy's planar tile format.
 The arguments are as follows:
 .Bl -tag -width Ds
-.It Fl b
-The output file is to be a binary (one bit per pixel) image.
-By default, the output file is two bits per pixel.
+.It Fl D
+Debug features are enabled.
 .It Fl f
 Fix the input PNG file to be a correctly indexed image.
 .It Fl F
@@ -28,10 +28,13 @@ Same as
 .Fl f ,
 but additionally, the input PNG file is fixed to have its parameters match the
 command line's parameters.
+.It Fl d Ar depth
+The bitdepth of the output image (either 1 or 2).
+By default, the bitdepth is 2 (two bits per pixel).
 .It Fl h
 Lay out tiles horizontally rather than vertically.
 .It Fl o Ar outfile
-The name of the output two bits per pixel, or one bit per pixel file.
+The name of the output file.
 .It Fl p Ar palfile
 Raw bytes (8 bytes for two bits per pixel, 4 bytes for one bit per pixel)
 containing the RGB15 values in the little-endian byte order and then ordered
@@ -52,39 +55,21 @@ but the tilemap file output name is made by taking the input filename,
 removing the file extension, and appending
 .Pa .tilemap .
 .It Fl v
-Print errors when the command line parameters and the parameters in the PNG
-file don't match.
+Verbose.
+Print errors when the command line parameters and the parameters in
+the PNG file don't match.
 .It Fl x Ar tiles
 Trim the end of the output file by this many tiles.
 .El
 .Sh EXAMPLES
-Most values in the ROM header are only cosmetic.
-The bare minimum requirements for a workable image are checksums, the Nintendo
-logo, and (if needed) the CGB/SGB flags.
-It is a good idea to pad the image to a valid size as well
-.Pq Do valid Dc meaning a multiple of 32KiB .
+The following will take a PNG file with a bitdepth of 1, 2, or 8, and output
+planar 2bpp data:
 .Pp
-The following will make a plain, no-color Game Boy game without checking for
-a valid size:
+.D1 $ rgbgfx -o out.2bpp in.png
 .Pp
-.D1 $ rgbfix \-v foo.gb
+The following will do nothing:
 .Pp
-The following will make a SGB-enabled, color-enabled game with a title of
-.Dq foobar ,
-and pad it to a multiple of 32KiB.
-.Po
-The Game Boy itself does not use the title, but some emulators or ROM managers
-might.
-.Pc
-.Pp
-.D1 $ rgbfix \-vcs \-l 0x33 \-p 0 \-t foobar baz.gb
-.Pp
-The following will duplicate the header
-.Pq sans global checksum
-of the game
-.Dq Survival Kids :
-.Pp
-.D1 $ rgbfix \-cjsv \-k A4 \-l 0x33 \-m 0x1B \-p 0xFF \-r 3 \-t SURVIVALKIDAVKE SurvivalKids.gbc
+.D1 $ rgbgfx in.png
 .Sh SEE ALSO
 .Xr rgbds 7 ,
 .Xr rgbasm 1 ,


### PR DESCRIPTION
Please test this if possible.

So far I have tested with:
- a png from pokered with bitdepth 2
- a png from pokered with bitdepth 1
- various pngs in mspaint with bitdepth 8
- a png from pokeruby with bitdepth 4

In particular `PNG_COLOR_TYPE_GRAY` was set by mspaint, so I'm wondering what needed this in `png_to_gb` to work.
